### PR TITLE
Use AppContext.BaseDirectory instead of Assembly.Location

### DIFF
--- a/HexConverter/AboutBoxMain.cs
+++ b/HexConverter/AboutBoxMain.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 Alex Kravchenko
+﻿// Copyright (c) 2022 - 2023 Alex Kravchenko
 
 using System;
 using System.Diagnostics;
@@ -19,7 +19,7 @@ namespace HexConverter
         {
             InitializeComponent();
             Text = $"About {productName}";
-            labelVersion.Text = $"Version {AssemblyVersionMajorMinor}";
+            labelVersion.Text = AssemblyVersionMajorMinor;
             labelCopyright.Text = AssemblyCopyright;
         }
 
@@ -73,7 +73,7 @@ namespace HexConverter
             {
                 if (e.Link.LinkData is string fileName)
                 {
-                    var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                    var directory = AppContext.BaseDirectory;
                     if (directory is not null)
                     {
                         processStartTarget = Path.Combine(directory, fileName);

--- a/HexConverter/FormMain.cs
+++ b/HexConverter/FormMain.cs
@@ -32,13 +32,13 @@ namespace HexConverter
                 return;
             }
 
-            if (_state.Maximised)
+            if (_state.Maximized)
             {
                 Location = _state.Location;
                 WindowState = FormWindowState.Maximized;
                 Size = _state.Size;
             }
-            else if (_state.Minimised)
+            else if (_state.Minimized)
             {
                 Location = _state.Location;
                 WindowState = FormWindowState.Minimized;
@@ -81,22 +81,22 @@ namespace HexConverter
             {
                 _state.Location = RestoreBounds.Location;
                 _state.Size = RestoreBounds.Size;
-                _state.Maximised = true;
-                _state.Minimised = false;
+                _state.Maximized = true;
+                _state.Minimized = false;
             }
             else if (WindowState == FormWindowState.Normal)
             {
                 _state.Location = Location;
                 _state.Size = Size;
-                _state.Maximised = false;
-                _state.Minimised = false;
+                _state.Maximized = false;
+                _state.Minimized = false;
             }
             else
             {
                 _state.Location = RestoreBounds.Location;
                 _state.Size = RestoreBounds.Size;
-                _state.Maximised = false;
-                _state.Minimised = true;
+                _state.Maximized = false;
+                _state.Minimized = true;
             }
 
             _state.Hex1 = textBoxHex1.Text;

--- a/HexConverter/PersistedState.cs
+++ b/HexConverter/PersistedState.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2022 Alex Kravchenko
+﻿// Copyright (c) 2022 - 2023 Alex Kravchenko
 
+using System;
 using System.Drawing;
 using System.IO;
-using System.Reflection;
 using System.Text.Json;
 
 namespace HexConverter
@@ -11,8 +11,8 @@ namespace HexConverter
     {
         public Point Location { get; set; }
         public Size Size { get; set; }
-        public bool Maximised { get; set; }
-        public bool Minimised { get; set; }
+        public bool Maximized { get; set; }
+        public bool Minimized { get; set; }
 
         public string Hex1 { get; set; } = string.Empty;
         public string Hex2 { get; set; } = string.Empty;
@@ -31,7 +31,7 @@ namespace HexConverter
 
         private static string GetFileName()
         {
-            var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var directory = AppContext.BaseDirectory;
             var filename = "state.json";
             return directory == null ? filename : Path.Combine(directory, filename);
         }


### PR DESCRIPTION
'System.Reflection.Assembly.Location' always returns an empty string for assemblies embedded in a single-file app. Therefore. LICENSE.txt was not displayed.
Also corrected spelling errors in two property names. 
Also removed "Version " prefix in the help-about info.